### PR TITLE
Fix invalid length being used for short_message copy

### DIFF
--- a/lib/pdu-parser.js
+++ b/lib/pdu-parser.js
@@ -160,7 +160,7 @@ exports.parse = function(buffer) {
         } else if (field.type === "string") {
             var length = result[field.length_field];
             var temp = new Buffer(length);
-            buffer.copy(temp, 0, offset, offset + field.length);
+            buffer.copy(temp, 0, offset, offset + length);
 
             result[field.name] = temp;
             offset += length;


### PR DESCRIPTION
Was getting garbage data from incoming short_message because length that was used in the buffer copy was invalid.
